### PR TITLE
Allow private mixins, placeholders and functions

### DIFF
--- a/__tests__/valid.scss
+++ b/__tests__/valid.scss
@@ -21,6 +21,10 @@
   @return $new-list;
 }
 
+@function -private-function() {
+  @return true;
+}
+
 @mixin corner-icon($name, $top-or-bottom, $left-or-right) {
   .icon-#{$name} {
     background-image: url("/icons/#{$name}.svg");
@@ -53,9 +57,17 @@
   box-shadow: 0 0 1px rgb($theme / 25%);
 }
 
+@mixin -private-mixin() {
+  border: 1px;
+}
+
 %message-shared {
   border: 1px solid #ccc;
   color: #333;
+}
+
+%-private-placeholder {
+  border: 1px;
 }
 
 $-private-size: 10rem;

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
 		'scss/at-else-if-parentheses-space-before': 'always',
 		'scss/at-function-parentheses-space-before': 'never',
 		'scss/at-function-pattern': [
-			'^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
+			'^(-?[a-z][a-z0-9]*)(-[a-z0-9]+)*$',
 			{
 				message: 'Expected function name to be kebab-case',
 			},
@@ -33,7 +33,7 @@ module.exports = {
 		'scss/at-mixin-argumentless-call-parentheses': 'never',
 		'scss/at-mixin-parentheses-space-before': 'never',
 		'scss/at-mixin-pattern': [
-			'^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
+			'^(-?[a-z][a-z0-9]*)(-[a-z0-9]+)*$',
 			{
 				message: 'Expected mixin name to be kebab-case',
 			},
@@ -49,7 +49,7 @@ module.exports = {
 			},
 		],
 		'scss/dollar-variable-pattern': [
-			'^([-a-z][a-z0-9]*)(-[a-z0-9]+)*$',
+			'^(-?[a-z][a-z0-9]*)(-[a-z0-9]+)*$',
 			{
 				message: 'Expected variable to be kebab-case',
 			},
@@ -63,7 +63,7 @@ module.exports = {
 		],
 		'scss/double-slash-comment-whitespace-inside': 'always',
 		'scss/percent-placeholder-pattern': [
-			'^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
+			'^(-?[a-z][a-z0-9]*)(-[a-z0-9]+)*$',
 			{
 				message: 'Expected placeholder to be kebab-case',
 			},


### PR DESCRIPTION
https://github.com/stylelint-scss/stylelint-config-standard-scss/pull/3 added support for private variables while linking to the [doc about Sass private members](https://sass-lang.com/documentation/at-rules/use#private-members). However, variables are not the only type of members.

This also fixes the pattern for private variables to forbid starting the Sass variable name with 2 dashes.
