### PR TITLE
Add optional postcss peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,13 @@
         "stylelint": "^14.9.0"
       },
       "peerDependencies": {
+        "postcss": "^8.3.3",
         "stylelint": "^14.14.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,12 @@
     "stylelint": "^14.9.0"
   },
   "peerDependencies": {
-    "stylelint": "^14.14.0"
+    "stylelint": "^14.14.0",
+    "postcss": "^8.3.3"
+  },
+  "peerDependenciesMeta": {
+    "postcss": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Similar to https://github.com/stylelint-scss/stylelint-config-recommended-scss/pull/112, this package implicitly needs `postcss` and therefore should mark it as peer dependency. 