### PR TITLE
Remove `import-notation` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ module.exports = {
 				ignoreAtRules: ['else'],
 			},
 		],
-		'import-notation': 'string',
 		'scss/at-else-closing-brace-newline-after': 'always-last-in-chain',
 		'scss/at-else-closing-brace-space-after': 'always-intermediate',
 		'scss/at-else-empty-line-before': 'never',


### PR DESCRIPTION
Related: https://github.com/stylelint/stylelint-config-standard/issues/265

This PR will remove the `import-notation` rule from our config to leave it up to the extending config `stylelint-config-standard`. As a result, the resolved option value will change to `'url'` from `'string'` so this change should be considered breaking.