### PR TITLE
set dollar-variable-colon-space-after to always-single-line

### DIFF
--- a/__tests__/valid.scss
+++ b/__tests__/valid.scss
@@ -164,3 +164,9 @@ $theme-colors: (
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+$ratios:
+    5 4,
+    4 3,
+    3 2,
+    16 9;

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
 			},
 		],
 		'scss/at-rule-conditional-no-parentheses': true,
-		'scss/dollar-variable-colon-space-after': 'always',
+		'scss/dollar-variable-colon-space-after': 'always-single-line',
 		'scss/dollar-variable-colon-space-before': 'never',
 		'scss/dollar-variable-empty-line-before': [
 			'always',


### PR DESCRIPTION
`'scss/dollar-variable-colon-space-after': 'always'` collides with the default formatting of Prettier when the value is broken into several lines.

For example, Prettier formats like this:

```css
$ratios:
    1 1,
    2 1,
    5 4,
    4 3,
    3 2,
    16 9,
    4 5,
    3 4,
    2 3,
    9 16;
```

While the rule set to `always` formats the same like this:

```css
$ratios: 1 1,
    2 1,
    5 4,
    4 3,
    3 2,
    16 9,
    4 5,
    3 4,
    2 3,
    9 16;
```

I propose to default to a setting that is compatible with Prettier.